### PR TITLE
Fix freeform invite in document.invite

### DIFF
--- a/lib/document/index.js
+++ b/lib/document/index.js
@@ -612,7 +612,7 @@ class Document {
    * Document invite settings
    * @typedef {Object} DocumentInviteSettings
    * @property {string} from - email of sender
-   * @property {SignerSettings[]|string[]|string} to - array of signers or email of single signer
+   * @property {SignerSettings[]|string} to - array of signers or email of single signer
    * @property {string} [document_id] - an id of document
    * @property {string[]} [cc] - array with emails of copy receivers
    * @property {string} [subject] - specify subject of email
@@ -668,13 +668,15 @@ class Document {
   }, callback) {
     const inviteData = Object.assign({}, data, { document_id: id });
 
-    try {
-      inviteData.to.forEach(signer => {
-        signer.role_id = signer.role_id || '';
-      });
-    } catch (err) {
-      callback(err);
-      return;
+    if (typeof(inviteData.to) !== 'string') {
+      try {
+        inviteData.to.forEach(signer => {
+          signer.role_id = signer.role_id || '';
+        });
+      } catch (err) {
+        callback(err);
+        return;
+      }
     }
 
     const JSONData = JSON.stringify(inviteData);


### PR DESCRIPTION
Fixing the `TypeError: inviteData.to.forEach is not a function` for the similar calls:
```javascript
api.document.invite({
  token: 'your auth token',
  id: 'document id',
  data: {
    from: 'email address',
    to: 'email address',
  },
}, (err, res) => {
  // handle error or process response data
});
```